### PR TITLE
Refactor Docker and Plugin Configuration for Ollama Integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,15 @@ API_PORT=54789
 # Logging Configuration
 LOG_LEVEL=INFO
 LOG_ENABLED=true
-LOG_RETENTION_DAYS=30  # Set to 0 for infinite retention
+# Set to 0 for infinite retention
+LOG_RETENTION_DAYS=30
 
 # Recordings directory path
 RECORDINGS_DIR="/path/to/your/recordings"
 
 # Directory Sync Configuration
-DIRECTORY_SYNC_ENABLED=false  # Set to true to enable directory synchronization
+# Set to true to enable directory synchronization
+DIRECTORY_SYNC_ENABLED=false
 # JSON array of source and destination directory pairs to monitor
 # Paths can be absolute or relative to the app root
 # DIRECTORY_SYNC_PAIRS='[{"source": "data/cleaned_audio", "destination": "data/processed_audio"},{"source": "/absolute/path/to/source", "destination": "/absolute/path/to/destination"}]'

--- a/README.md
+++ b/README.md
@@ -49,21 +49,26 @@ Note: The memory requirements are primarily driven by the LLM model size and ope
 
 ## Installation
 
-### Quick Setup (Recommended)
+### Prerequisites
 
-The easiest way to set up the application is to use the provided setup script. 
+1. **Install Ollama** (for local meeting notes generation)
+   - Download and install Ollama from the official website: [https://ollama.com/download](https://ollama.com/download)
+   - This step must be completed before running the setup script
+   - Do not use Homebrew for Ollama installation unless you specifically prefer it
 
-#### Prerequisites
-
-1. **macOS Users**: You need Homebrew installed. If you don't have it, install it with:
+2. **macOS Users**: You need Homebrew installed. If you don't have it, install it with:
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-2. Ensure Python 3.12 is installed on your system:
+3. Ensure Python 3.12 is installed on your system:
 ```bash
 python --version  # Should show Python 3.12.x
 ```
+
+### Quick Setup (Recommended)
+
+The easiest way to set up the application is to use the provided setup script. 
 
 #### Running the Setup
 
@@ -96,28 +101,23 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env  # Add Rust to your current shell session
 ```
 
-2. Install Ollama (required for meeting notes generation):
-```bash
-curl https://ollama.ai/install.sh | sh
-```
-
-3. Install OpenAI Whisper (required for audio transcription):
+2. Install OpenAI Whisper (required for audio transcription):
 ```bash
 brew install openai-whisper
 ```
 
-4. Clone the repository:
+3. Clone the repository:
 ```bash
 git clone https://github.com/yourusername/panottiServer.git
 cd panottiServer
 ```
 
-5. Install Poetry (if not already installed):
+4. Install Poetry (if not already installed):
 ```bash
 curl -sSL https://install.python-poetry.org | python3 -
 ```
 
-6. Set up Python 3.12 using pyenv:
+5. Set up Python 3.12 using pyenv:
 ```bash
 # Install pyenv
 brew install pyenv
@@ -129,7 +129,7 @@ pyenv install 3.12
 pyenv local 3.12
 ```
 
-7. Install dependencies using Poetry:
+6. Install dependencies using Poetry:
 ```bash
 # Install dependencies
 poetry install
@@ -138,13 +138,13 @@ poetry install
 poetry shell
 ```
 
-8. Create a `.env` file based on `.env.example`:
+7. Create a `.env` file based on `.env.example`:
 ```bash
 cp .env.example .env
 ```
 Then edit `.env` with your actual configuration values.
 
-9. Set up HTTPS (optional):
+8. Set up HTTPS (optional):
 ```bash
 # Create SSL directory
 mkdir -p ssl
@@ -161,6 +161,13 @@ Note: When using self-signed certificates in development, your browser will show
 
 The application can be run using Docker and Docker Compose for easier deployment and consistent environments.
 
+> ⚠️ **IMPORTANT WARNING**: Running Ollama within Docker is **strongly discouraged** due to significant resource constraints and potential stability issues. It is highly recommended to:
+> 1. Run Ollama directly on your host machine
+> 2. Run only the application in Docker
+> 3. Configure the application to connect to your host's Ollama server
+>
+> This approach provides better performance and stability while maintaining the benefits of containerization for the main application.
+
 #### Prerequisites
 
 1. Install Docker:
@@ -174,16 +181,37 @@ curl -fsSL https://get.docker.com | sh
 
 2. Start Docker service (if not already running)
 
-#### Running with Docker Compose
+#### Configuration
 
-1. Build and start the containers:
-```bash
-docker-compose up --build
+The application uses two Docker Compose files:
+- `docker-compose.yml`: Core application configuration
+- `docker-compose.ollama.yml`: Optional Ollama service configuration
+
+When using host's Ollama, update your plugin configuration in `app/plugins/meeting_notes_local/plugin.yaml`:
+```yaml
+ollama_url: "http://host.docker.internal:11434/api/generate"  # macOS/Windows
+# or
+ollama_url: "http://172.17.0.1:11434/api/generate"  # Linux
 ```
 
-2. To run in detached mode (background):
+#### Running with Docker Compose
+
+1. Using host's Ollama (recommended):
 ```bash
+# Build and start the application
+docker-compose up --build
+
+# Run in detached mode
 docker-compose up -d
+```
+
+2. Using Docker's Ollama (not recommended):
+```bash
+# Build and start with Ollama
+docker-compose -f docker-compose.yml -f docker-compose.ollama.yml up --build
+
+# Run in detached mode
+docker-compose -f docker-compose.yml -f docker-compose.ollama.yml up -d
 ```
 
 3. To stop the containers:
@@ -202,17 +230,29 @@ docker compose down
 
 2. Rebuild the containers without using cache:
 ```bash
+# For host Ollama (recommended):
 docker compose build --no-cache app
+
+# For Docker Ollama (not recommended):
+docker compose -f docker-compose.yml -f docker-compose.ollama.yml build --no-cache
 ```
 
 3. Start the containers again:
 ```bash
+# For host Ollama (recommended):
 docker compose up -d
+
+# For Docker Ollama (not recommended):
+docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d
 ```
 
 All in one command:
-```
+```bash
+# For host Ollama (recommended):
 docker compose down && docker compose build --no-cache app && docker compose up -d
+
+# For Docker Ollama (not recommended):
+docker compose down && docker compose -f docker-compose.yml -f docker-compose.ollama.yml build --no-cache && docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d
 ```
 
 #### Running with Docker directly
@@ -257,6 +297,24 @@ Notes:
 - The feature can be disabled by setting `DIRECTORY_SYNC_ENABLED=false`
 - Source directories are monitored recursively
 - Files are copied with their metadata preserved
+
+#### Docker Considerations
+
+When running the application in Docker, to sync directories between your host machine and the container:
+
+1. First add a volume mount in your `docker-compose.yml`:
+```yaml
+volumes:
+  - /path/on/host:/path/in/container
+```
+
+2. Then configure the sync in your `.env` file using the container paths:
+```env
+DIRECTORY_SYNC_ENABLED=true
+DIRECTORY_SYNC_PAIRS='[{"source": "/path/in/container", "destination": "/other/path/in/container"}]'
+```
+
+Note: Always use the paths as they appear inside the container when configuring `DIRECTORY_SYNC_PAIRS`, not the host paths.
 
 ### Starting the Server
 

--- a/app/plugins/meeting_notes_local/README.md
+++ b/app/plugins/meeting_notes_local/README.md
@@ -20,14 +20,21 @@ To set up the plugin configuration:
 The configuration supports the following options:
 
 - `output_directory`: Directory where meeting notes will be stored
-- `ollama_url`: URL for Ollama API (default: http://localhost:11434/api/generate)
+- `ollama_url`: URL for Ollama API. Options:
+  - Local Ollama (default): `http://localhost:11434/api/generate`
+  - Docker on macOS/Windows using host Ollama: `http://host.docker.internal:11434/api/generate`
+  - Docker on Linux using host Ollama: `http://172.17.0.1:11434/api/generate`
 - `model_name`: Ollama model to use (default: llama2:latest)
 - `num_ctx`: Context window size (default: 128000)
 - `max_concurrent_tasks`: Maximum number of concurrent processing tasks
+- `timeout`: Request timeout in seconds (default: 900)
 
 ## Requirements
 
-- Ollama server running locally with the specified model
+- Ollama server running either (all options requires setting the appropriate `ollama_url`):
+  - On the host machine, running the app as a standalone process (default)
+  - On the host machine, but called from the app running in Docker
+  - Runnig ollama within Docker (not recommended)
 - Python packages (see requirements.txt):
   - requests>=2.31.0
 

--- a/app/plugins/meeting_notes_local/plugin.py
+++ b/app/plugins/meeting_notes_local/plugin.py
@@ -28,12 +28,9 @@ class MeetingNotesLocalPlugin(PluginBase):
         """Initialize the plugin"""
         super().__init__(config, event_bus)
         self._req_id = str(uuid.uuid4())
-
-        # Check if we're running in Docker first
-        is_docker = os.path.exists('/.dockerenv')
         
         # Default values
-        self.ollama_url = "http://ollama:11434/api/generate" if is_docker else "http://localhost:11434/api/generate"
+        self.ollama_url = "http://localhost:11434/api/generate"
         self.model = "llama3.1:latest"
         self.output_dir = Path("data/meeting_notes_local")
         self.num_ctx = 128000
@@ -44,9 +41,7 @@ class MeetingNotesLocalPlugin(PluginBase):
         if config and hasattr(config, "config"):
             config_dict = config.config
             if isinstance(config_dict, dict):
-                # Don't override ollama_url if we're in Docker
-                if not is_docker:
-                    self.ollama_url = config_dict.get("ollama_url", self.ollama_url)
+                self.ollama_url = config_dict.get("ollama_url", self.ollama_url)
                 self.model = config_dict.get("model_name", self.model)
                 self.output_dir = Path(config_dict.get("output_directory", str(self.output_dir)))
                 self.num_ctx = config_dict.get("num_ctx", self.num_ctx)
@@ -66,8 +61,7 @@ class MeetingNotesLocalPlugin(PluginBase):
                 "plugin_name": self.name,
                 "output_directory": str(self.output_dir),
                 "ollama_url": self.ollama_url,
-                "num_ctx": self.num_ctx,
-                "is_docker": is_docker
+                "num_ctx": self.num_ctx
             }
         )
 

--- a/app/plugins/meeting_notes_local/plugin.yaml.example
+++ b/app/plugins/meeting_notes_local/plugin.yaml.example
@@ -4,6 +4,10 @@ enabled: true
 dependencies: ["audio_transcription"]
 config:
   output_directory: "data/meeting_notes_local"
+  # Ollama URL configuration:
+  # - For local Ollama (default): "http://localhost:11434/api/generate"
+  # - For Docker on macOS/Windows using host Ollama: "http://host.docker.internal:11434/api/generate"
+  # - For Docker on Linux using host Ollama: "http://172.17.0.1:11434/api/generate"
   ollama_url: "http://localhost:11434/api/generate"
   model_name: "llama3.1:latest"
   num_ctx: 131072

--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -1,0 +1,71 @@
+services:
+  app-with-ollama:
+    extends:
+      file: docker-compose.yml
+      service: app
+    depends_on:
+      ollama:
+        condition: service_healthy
+        required: true
+    command: >
+      sh -c "
+      echo 'Waiting for Docker Ollama to be healthy...' &&
+      until curl -s http://ollama:11434/api/version > /dev/null; do
+        echo 'Waiting for Ollama...' &&
+        sleep 5;
+      done &&
+      echo 'Docker Ollama is ready!' &&
+      echo '=== Environment ===' &&
+      env | sort &&
+      echo '=== Directory Structure ===' &&
+      ls -laR /app &&
+      echo '=== Starting App ===' &&
+      /app/docker-entrypoint.sh
+      "
+
+  ollama:
+    build: 
+      context: ./docker/ollama
+      dockerfile: Dockerfile
+    ports:
+      - "11435:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+      - /dev/shm:/dev/shm
+    environment:
+      - GIN_MODE=release
+      - OLLAMA_ORIGINS=*
+      - OLLAMA_HOST=0.0.0.0:11434
+      - OLLAMA_COMPUTE=cpu
+      - OLLAMA_MODELS=/root/.ollama/models
+      - OLLAMA_CTX_SIZE=131072
+      - OLLAMA_TIMEOUT=600
+      - OLLAMA_GPU_LAYERS=0
+      - OLLAMA_THREADS=8
+      - GOAMD64=v3
+    ipc: host
+    deploy:
+      resources:
+        limits:
+          memory: 70G
+          cpus: '8'
+        reservations:
+          memory: 32G
+          cpus: '4'
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    shm_size: '16gb'
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:11434/api/version || exit 0"]
+      interval: 60s
+      timeout: 600s
+      retries: 15
+      start_period: 180s
+    restart: unless-stopped
+
+volumes:
+  ollama_data: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,22 @@ services:
     build: .
     ports:
       - "${API_PORT}:${API_PORT}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
       - ./.env:/app/.env
       - ./scripts:/app/scripts
       - ./ssl:/app/ssl
-      - ./app/plugins:/app/app/plugins
+      - ./app/core:/app/app/core
+      - ./app/models:/app/app/models
+      - ./app/utils:/app/app/utils
+      - ./app/__init__.py:/app/app/__init__.py
+      - ./app/main.py:/app/app/main.py
+      - ./app/plugins/*/*.py:/app/app/plugins/*/plugin.py
+      - ./app/plugins/*/requirements.txt:/app/app/plugins/*/requirements.txt
       - whisper_models:/app/models/whisper
-      - ./app:/app/app
       - ./app/plugins/meeting_notes_remote/plugin.yaml:/app/app/plugins/meeting_notes_remote/plugin.yaml
       - ./app/plugins/meeting_notes_local/plugin.yaml:/app/app/plugins/meeting_notes_local/plugin.yaml
       - ./app/plugins/desktop_notifier/plugin.yaml:/app/app/plugins/desktop_notifier/plugin.yaml
@@ -32,9 +39,6 @@ services:
       - API_PORT=${API_PORT}
       - OLLAMA_MODEL=llama3.1:latest
       - OLLAMA_TIMEOUT=600
-    depends_on:
-      ollama:
-        condition: service_healthy
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-k", "-f", "https://127.0.0.1:${API_PORT}/docs"]
@@ -44,12 +48,6 @@ services:
       start_period: 120s
     command: >
       sh -c "
-      echo 'Waiting for Ollama to be healthy...' &&
-      until curl -s http://ollama:11434/api/version > /dev/null; do
-        echo 'Waiting for Ollama...' &&
-        sleep 5;
-      done &&
-      echo 'Ollama is ready!' &&
       echo '=== Environment ===' &&
       env | sort &&
       echo '=== Directory Structure ===' &&
@@ -58,50 +56,5 @@ services:
       /app/docker-entrypoint.sh
       "
 
-  ollama:
-    build: 
-      context: ./docker/ollama
-      dockerfile: Dockerfile
-    ports:
-      - "11435:11434"
-    volumes:
-      - ollama_data:/root/.ollama
-      - /dev/shm:/dev/shm
-    environment:
-      - GIN_MODE=release
-      - OLLAMA_ORIGINS=*
-      - OLLAMA_HOST=0.0.0.0:11434
-      - OLLAMA_COMPUTE=cpu
-      - OLLAMA_MODELS=/root/.ollama/models
-      - OLLAMA_CTX_SIZE=131072
-      - OLLAMA_TIMEOUT=600
-      - OLLAMA_GPU_LAYERS=0
-      - OLLAMA_THREADS=8
-      - GOAMD64=v3
-    ipc: host
-    deploy:
-      resources:
-        limits:
-          memory: 70G
-          cpus: '8'
-        reservations:
-          memory: 32G
-          cpus: '4'
-    ulimits:
-      memlock: -1
-      stack: 67108864
-    shm_size: '16gb'
-    dns:
-      - 8.8.8.8
-      - 8.8.4.4
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:11434/api/version || exit 0"]
-      interval: 60s
-      timeout: 600s
-      retries: 15
-      start_period: 180s
-    restart: unless-stopped
-
 volumes:
-  ollama_data:
   whisper_models: 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -48,7 +48,6 @@ def install_system_dependencies():
     brew_packages = [
         "openai-whisper",  # Required for audio transcription
         "terminal-notifier",  # Required for desktop notifications
-        "ollama",  # Required for local LLM processing
         "ffmpeg",  # Required for audio processing
         "pyenv",  # Recommended for Python version management
     ]
@@ -211,10 +210,10 @@ def main():
 
         print("\nSetup completed successfully! 🚀")
         print("\nTo start the server, run one of the following commands:")
-        print("1. Using Python directly:")
-        print("   poetry run python run_server.py")
-        print("\n2. Using the shell script (recommended):")
+        print("1. Using the shell script (recommended):")
         print("   ./start_server.sh")
+        print("\n2. Using Python directly:")
+        print("   poetry run python run_server.py")
         print("\nThe server will be available at:")
         print("- HTTPS: https://localhost:54789")
         print("\nAPI documentation will be available at:")


### PR DESCRIPTION
- Introduced a new docker-compose.ollama.yml file to manage the Ollama service separately, enhancing modularity.
- Updated docker-compose.yml to remove the embedded Ollama service and added extra_hosts for host communication.
- Modified .env.example to clarify logging and directory sync configurations.
- Adjusted MeetingNotesLocalPlugin to use a fixed Ollama URL, simplifying the configuration.
- Enhanced README.md with detailed instructions for using Ollama with Docker, including recommended practices and configuration options.
- Updated plugin.yaml.example to provide clear Ollama URL options for different environments.
- Removed direct Ollama installation from setup.py to encourage running Ollama on the host machine for better performance.